### PR TITLE
Moved to the native linux at3tools binary, resolves #10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
-psp_at3tool.exe
+psp_at3tool
+libatrac.so.1.2.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,15 +9,16 @@ RUN mv ffmpeg-build/artifacts/ffmpeg-*-linux-gnu/bin/ffmpeg .
 
 FROM python:3.11-slim
 
-ENV WINEPREFIX="/wine32" 
-ENV WINEARCH=win32 
-ENV LOG_LEVEL=
-RUN dpkg --add-architecture i386
-RUN apt-get update && apt-get install -y wine32 wine:i386 --no-install-recommends
-RUN apt-get clean
-RUN /usr/bin/wine wineboot | true
 COPY --from=builder /root/ffmpeg /usr/bin/ffmpeg
-COPY psp_at3tool.exe .
+
+# Necessary to run at3tool
+RUN apt-get update && apt-get install -y gcc-multilib
+COPY libatrac.so.1.2.0 /usr/local/lib
+RUN ldconfig
+RUN ln -s /usr/local/lib/libatrac.so.1 /usr/local/lib/libatrac.so
+ENV LD_LIBRARY_PATH /usr/local/lib
+COPY psp_at3tool /usr/bin/at3tool
+
 COPY requirements.txt .
 RUN pip install -r requirements.txt
 RUN mkdir /uploads

--- a/utils.py
+++ b/utils.py
@@ -19,6 +19,7 @@ class atracTypes(str, Enum):
   PLUS320 = 'PLUS320'
   PLUS352 = 'PLUS352'
 
+
 bitrates = {
   'LP2':     132,
   'LP4':     66,
@@ -34,6 +35,7 @@ bitrates = {
   'PLUS352': 352
 }
 
+
 def allowed_file(filename):
     return '.' in filename and \
            filename.rsplit('.', 1)[1].lower() in ['wav', 'at3']
@@ -46,7 +48,7 @@ def remove_file(filename, logger):
 
 def do_encode(input, type, logger):
   output = Path(gettempdir(), str(uuid4())).absolute()
-  subprocess.run(['/usr/bin/wine', 'psp_at3tool.exe', '-e', '-br', str(bitrates[type]), 
-    input, 
+  subprocess.run(['/usr/bin/at3tool', '-e', '-br', str(bitrates[type]),
+    input,
     output])
   return output


### PR DESCRIPTION
Removed wine and switched to the Linux native at3tools binary, this requires the Linux binary of `psp_at3tools` and `libatrac.so.1.2.0` to be placed in the directory when building.