### PR TITLE
bumped python-multipart

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ idna==3.4
 packaging==23.0
 pydantic==1.10.4
 python-dotenv==0.21.1
-python-multipart==0.0.5
+python-multipart==0.0.20
 PyYAML==6.0
 six==1.16.0
 sniffio==1.3.0


### PR DESCRIPTION
Bulding the docker image wasn't successful, ending with following error:

`Building wheels for collected packages: python-multipart
Building wheel for python-multipart (setup.py): started
Building wheel for python-multipart (setup.py): finished with status 'error'
error: subprocess-exited-with-error

× python setup.py bdist_wheel did not run successfully.
│ exit code: 1
╰─> [6 lines of output]
usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
or: setup.py --help [cmd1 cmd2 ...]
or: setup.py --help-commands
or: setup.py cmd --help

error: invalid command 'bdist_wheel'`

Bumping up `python-multipart` to version 0.0.20 did the trick.